### PR TITLE
build(docker): multi-stage, drop cron, add tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,59 @@
-FROM ghcr.io/astral-sh/uv:0.11.9-python3.13-bookworm-slim
+# syntax=docker/dockerfile:1.7
 
-# Set labels
+# ============================================================
+# Stage 1: Builder - resolve and install Python dependencies
+# ============================================================
+FROM ghcr.io/astral-sh/uv:0.11.9-python3.13-trixie-slim AS builder
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+WORKDIR /app
+
+# Install dependencies separately from the project so this layer caches
+# unless uv.lock or pyproject.toml change.
+COPY uv.lock pyproject.toml README.md LICENSE ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev --no-install-project
+
+# Install the project itself
+COPY src/ ./src/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+# ============================================================
+# Stage 2: Runtime - lean production image
+# ============================================================
+FROM python:3.13-slim-trixie
+
+# Runtime-only system deps. tini gives us proper PID 1 signal handling so
+# APScheduler shuts down cleanly on SIGTERM.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        tar \
+        tini \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >/etc/timezone
+
+WORKDIR /app
+
+# Copy the built virtualenv and project source from the builder stage
+COPY --from=builder /app/.venv ./.venv
+COPY src/ ./src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+# OCI labels last so editing them doesn't bust the build cache
 LABEL org.opencontainers.image.source=https://github.com/natelandau/ezbak
 LABEL org.opencontainers.image.description="ezbak"
 LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.url=https://github.com/natelandau/ezbak
 LABEL org.opencontainers.image.title="ezbak"
 
-# Install Apt Packages
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates tar tzdata cron
-
-# Set timezone
-ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >/etc/timezone
-
-# Enable bytecode compilation
-ENV UV_COMPILE_BYTECODE=1
-
-# Set the working directory
-WORKDIR /app
-
-# Copy the project into the image
-COPY uv.lock pyproject.toml README.md LICENSE ./
-COPY src/ ./src/
-
-RUN uv sync --locked --no-dev --no-cache
-
-# Place executables in the environment at the front of the path
-ENV PATH="/app/.venv/bin:$PATH"
-
-# Reset the entrypoint, don't invoke `uv`
-ENTRYPOINT []
-
-# Run ezbak
-CMD [".venv/bin/python", "-m", "ezbak.entrypoint"]
+ENTRYPOINT ["tini", "--"]
+CMD ["python", "-m", "ezbak.entrypoint"]


### PR DESCRIPTION
## Summary
- Multi-stage build: runtime no longer carries the uv binary, build metadata, or apt lists.
- Drop `cron` apt package — unused; ezbak schedules in-process via APScheduler (`src/ezbak/entrypoint.py`).
- Add `tini` as PID 1 so APScheduler shuts down cleanly on SIGTERM.
- BuildKit cache mounts for uv; split `--no-install-project` dep install from project install so the dep layer survives source-only changes.
- Align builder base on `trixie-slim` to match the runtime; clean apt lists; move OCI labels below stable layers.
- Runs as root is preserved — `chown_files` (`src/ezbak/utils/helpers.py:23`) requires uid 0 to chown restored files.

## Test plan
- [ ] CI image build succeeds
- [ ] Container starts and one-shot backup runs to completion
- [ ] Scheduled (cron) mode runs at least one job and exits cleanly on SIGTERM
- [ ] Restore path still chowns files to the configured uid/gid